### PR TITLE
Bugfix: hash member editing

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -38,12 +38,11 @@ if (isset($_POST['type'], $_POST['key'], $_POST['value'])) {
       die('ERROR: Your hash key is to long (max length is '.$config['maxkeylen'].')');
     }
 
-    $redis->hSet($_POST['key'], $_POST['hkey'], $_POST['value']);
-
-    if ($edit) {
+    if ($edit && !$redis->hExists($_POST['key'], $_POST['hkey'])) {
       $redis->hDel($_POST['key'], $_GET['hkey']);
     }
 
+    $redis->hSet($_POST['key'], $_POST['hkey'], $_POST['value']);
   }
 
   // List


### PR DESCRIPTION
Only delete original hash member during edit if hash key is being changed.

Minor update to logic.

Now will only delete the member with the original key if the key passed via `$_POST['hkey']` doesn't exist (indicates a re-named member).
