### PR TITLE
Adding possibility to load just parts of database by configuration

### DIFF
--- a/common.inc.php
+++ b/common.inc.php
@@ -70,6 +70,9 @@ if (!isset($server['db'])) {
   $server['db'] = 0;
 }
 
+if (!isset($server['filter'])) {
+  $server['filter'] = '*';
+}
 
 // Setup a connection to Redis.
 $redis = new Predis\Client('tcp://'.$server['host'].':'.$server['port']);

--- a/config.inc.php
+++ b/config.inc.php
@@ -6,6 +6,7 @@ $config = array(
       'name' => 'local server', // Optional name.
       'host' => '127.0.0.1',
       'port' => 6379,
+      'filter' => '*'
 
       // Optional Redis authentication.
       //'auth' => 'redispasswordhere' // Warning: The password is sent in plain-text to the Redis server.
@@ -21,6 +22,7 @@ $config = array(
       'host' => 'localhost',
       'port' => 6379,
       'db'   => 1 // Optional database number, see http://redis.io/commands/select
+      'filter' => 'something:*' // Show only parts of database for speed or security reasons
     )*/
   ),
 

--- a/index.php
+++ b/index.php
@@ -5,8 +5,8 @@ require_once 'common.inc.php';
 
 
 
-// Get all keys from Redis.
-$keys = $redis->keys('*');
+// Get keys from Redis according to server-config.
+$keys = $redis->keys($server['filter']);
 
 sort($keys);
 


### PR DESCRIPTION
When phpRedisAdmin is used with large databases, it uses quite some time to loop over each and every key. The filter helps to just process the data which is needed. For example if you just want to edit some config-values stored in redis, but don't want to see all the page statistics collected in redis. What do you think about it?
