### PR TITLE
Allow for info property name change in Redis 2.6

### DIFF
--- a/overview.php
+++ b/overview.php
@@ -32,6 +32,10 @@ foreach ($config['servers'] as $i => $server) {
 
   $info[$i]         = $redis->info();
   $info[$i]['size'] = $redis->dbSize();
+  
+  if ($info[$i]['redis_version'] < '2.6') {
+    $info[$i]['rdb_last_save_time'] = $info[$i]['last_save_time'];
+  }		
 }
 
 
@@ -58,7 +62,7 @@ require 'header.inc.php';
 
   <tr><td><div>Uptime:</div></td><td><div><?php echo format_ago($info[$i]['uptime_in_seconds'])?></div></td></tr>
 
-  <tr><td><div>Last save:</div></td><td><div><?php echo format_ago(time() - $info[$i]['last_save_time'], true)?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
+  <tr><td><div>Last save:</div></td><td><div><?php echo format_ago(time() - $info[$i]['rdb_last_save_time'], true)?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
 
   </table>
   </div>


### PR DESCRIPTION
last_save_time has been renamed to rdb_last_save_time.
I'm checking if version is < 2.6 to determine if we need to copy the value of the last_save_time into ddb_last_save_time before display
