### PR TITLE
Added per server configuration for seperator

### DIFF
--- a/includes/common.inc.php
+++ b/includes/common.inc.php
@@ -78,6 +78,10 @@ if (!isset($server['filter'])) {
   $server['filter'] = '*';
 }
 
+if (!isset($server['seperator'])) {
+  $server['seperator'] = $config['seperator'];
+}
+
 // Setup a connection to Redis.
 $redis = new Predis\Client('tcp://'.$server['host'].':'.$server['port']);
 

--- a/includes/config.sample.inc.php
+++ b/includes/config.sample.inc.php
@@ -7,7 +7,7 @@ $config = array(
       'name' => 'local server', // Optional name.
       'host' => '127.0.0.1',
       'port' => 6379,
-      'filter' => '*'
+      'filter' => '*',
 
       // Optional Redis authentication.
       //'auth' => 'redispasswordhere' // Warning: The password is sent in plain-text to the Redis server.
@@ -24,6 +24,7 @@ $config = array(
       'port' => 6379,
       'db'   => 1 // Optional database number, see http://redis.io/commands/select
       'filter' => 'something:*' // Show only parts of database for speed or security reasons
+      'seperator' => '/', // Use a different seperator on this database
     )*/
   ),
 

--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@ foreach ($keys as $key) {
     continue;
   }
 
-  $key = explode($config['seperator'], $key);
+  $key = explode($server['seperator'], $key);
 
   // $d will be a reference to the current namespace.
   $d = &$namespaces;
@@ -132,7 +132,7 @@ function print_namespace($item, $name, $fullkey, $islast) {
       if ($fullkey === '') {
         $childfullkey = $childname;
       } else {
-        $childfullkey = $fullkey.$config['seperator'].$childname;
+        $childfullkey = $fullkey.$server['seperator'].$childname;
       }
 
       print_namespace($childitem, $childname, $childfullkey, (--$l == 0));


### PR DESCRIPTION
We use a different seperator scheme on one database (to serve temporary web resources, so in this case a slash "/").

To support having a different seperator on a single database, I added the ability to configure it on a per connection basis and use the default setting if it's not configured.
