### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2,7 +2,7 @@
 
 function format_html($str, $from_encoding = FALSE) {
   $res = $from_encoding ? mb_convert_encoding($str, 'utf-8', $from_encoding) : $str;
-  $res = htmlentities($res, ENT_QUOTES | ENT_SUBSTITUTE, 'utf-8');
+  $res = htmlentities($res, ENT_QUOTES | ENT_IGNORE, 'utf-8');
   return ($res || !$str) ? $res :  '(' . strlen($str) . ' bytes)';
 }
 


### PR DESCRIPTION
ENT_SUBSTITUTE flag doesn't exist for HP 5.3 and ENT_IGNORE seems to be sufficient
