### PR TITLE
Remove maxlength limit from edit control and sort values of list, set, zset

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -147,12 +147,12 @@ require 'includes/header.inc.php';
 
 <p>
 <label for="key">Key:</label>
-<input type="text" name="key" id="key" size="30" maxlength="30" <?php echo isset($_GET['key']) ? 'value="'.format_html($_GET['key']).'"' : ''?>>
+<input type="text" name="key" id="key" size="30" <?php echo isset($_GET['key']) ? 'value="'.format_html($_GET['key']).'"' : ''?>>
 </p>
 
 <p id="hkeyp">
 <label for="khey">Hash key:</label>
-<input type="text" name="hkey" id="hkey" size="30" maxlength="30" <?php echo isset($_GET['hkey']) ? 'value="'.format_html($_GET['hkey']).'"' : ''?>>
+<input type="text" name="hkey" id="hkey" size="30" <?php echo isset($_GET['hkey']) ? 'value="'.format_html($_GET['hkey']).'"' : ''?>>
 </p>
 
 <p id="indexp">

--- a/view.php
+++ b/view.php
@@ -69,6 +69,7 @@ switch ($type) {
   case 'hash':
     $values = $redis->hGetAll($_GET['key']);
     $size   = count($values);
+    ksort($values);
     break;
 
   case 'list':
@@ -78,11 +79,13 @@ switch ($type) {
   case 'set':
     $values = $redis->sMembers($_GET['key']);
     $size   = count($values);
+    sort($values);
     break;
 
   case 'zset':
     $values = $redis->zRange($_GET['key'], 0, -1);
     $size   = count($values);
+    ksort($values);
     break;
 }
   

--- a/view.php
+++ b/view.php
@@ -85,7 +85,6 @@ switch ($type) {
   case 'zset':
     $values = $redis->zRange($_GET['key'], 0, -1);
     $size   = count($values);
-    ksort($values);
     break;
 }
   


### PR DESCRIPTION
### Remove maxlength limit from edit control.

Sometimes I really need a long key.

### Sort values of list, set, zset

It's more easier to read.