### PR TITLE
die on an exception occurred.

### DIFF
--- a/includes/common.inc.php
+++ b/includes/common.inc.php
@@ -121,7 +121,7 @@ if(isset($server['scheme']) && $server['scheme'] === 'unix' && $server['path']) 
 try {
     $redis->connect();
 } catch (Predis\CommunicationException $exception) {
-    $redis = false;
+    die('ERROR: ' . $exception->getMessage());
 }
 
 if (isset($server['auth'])) {


### PR DESCRIPTION
otherwise it will get a inaccurate ERROR MSG when connect refused (e.g. a wrong server address) .