### PR TITLE
Add Docker usage docs and Docker Compose manifest for testing/development

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,16 @@ cd phpRedisAdmin
 git clone https://github.com/nrk/predis.git vendor
 ```
 
+Docker Image
+============
+A public [phpRedisAdmin Docker image](https://hub.docker.com/r/erikdubbelboer/phpredisadmin/) is available on Docker Hub [automatically built](https://docs.docker.com/docker-hub/builds/) from latest source.
+The file ```includes/config.environment.inc.php``` is used as the configuration file to allow environment variables to be used as configuration values.
+Example:
+```
+docker run --rm -it -e REDIS_1_HOST=myredis.host -e REDIS_1_NAME=MyRedis -p 80:80 erikdubbelboer/phpredisadmin
+```
+Also, a Docker Compose manifest with a stack for testing and development is provided. Just issue ```docker-compose up --build``` to start it and browse to http://localhost. See ```docker-compose.yml``` file for configuration details.
+
 TODO
 ====
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+phpredisadmin:
+  build: .
+  environment:
+    - ADMIN_USER=admin
+    - ADMIN_PASS=admin
+    - REDIS_1_HOST=redis
+    - REDIS_1_PORT=6379
+  links:
+    - redis
+  ports:
+    - "80:80"
+
+redis:
+  image: redis
+  command: --loglevel verbose

--- a/includes/config.environment.inc.php
+++ b/includes/config.environment.inc.php
@@ -14,6 +14,7 @@ if (!empty($admin_user)) {
 }
 
 $i=1;
+$config['servers'] = array();
 
 while (TRUE) {
 


### PR DESCRIPTION
Just requires Docker Compose. See docs.
Docker Compose is most likely present on all developers using Docker workflow environments.
Related to #72.