### PR TITLE
Correction time shows that time is more scientific

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -26,7 +26,7 @@ function input_convert($str) {
 }
 
 
-function format_ago($time) {
+function format_time($time) {
   $minute = 60;
   $hour   = $minute * 60;
   $day    = $hour   * 24;
@@ -67,7 +67,7 @@ function format_size($size) {
 
 function format_ttl($seconds) {
 	if ($seconds > 60) {
-		return sprintf('%d (%s)', $seconds, format_ago($seconds));
+		return sprintf('%d (%s)', $seconds, format_time($seconds));
 	} else {
 		return $seconds;
 	}

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -26,39 +26,30 @@ function input_convert($str) {
 }
 
 
-function format_ago($time, $ago = false) {
+function format_ago($time) {
   $minute = 60;
   $hour   = $minute * 60;
   $day    = $hour   * 24;
 
   $when = $time;
 
-  if ($when >= 0)
-    $suffix = 'ago';
-  else {
-    $when = -$when;
-    $suffix = 'in the future';
-  }
-
   if ($when > $day) {
-    $when = round($when / $day);
-    $what = 'day';
+    $tmpday = floor($when / $day);
+    $tmphour = floor(($when / $hour) - (24*$tmpday));
+    $tmpminute = floor(($when / $minute) - (24*60*$tmpday) - ($tmphour * 60));
+    $tmpsec = floor($when - (24*60*60*$tmpday) - ($tmphour * 60 * 60) - ($tmpminute * 60));
+    return sprintf("%d day %d hour %d minute %d sec",$tmpday,$tmphour,$tmpminute,$tmpsec);
   } else if ($when > $hour) {
-    $when = round($when / $hour);
-    $what = 'hour';
+    $tmphour = floor($when / $hour);
+    $tmpminute = floor(($when / $minute) - ($tmphour * 60));
+    $tmpsec = floor($when - ($tmphour * 60 * 60) - ($tmpminute * 60));
+    return sprintf("%d hour %d min %d sec",$tmphour,$tmpminute,$tmpsec);
   } else if ($when > $minute) {
-    $when = round($when / $minute);
-    $what = 'minute';
+    $tmpminute = floor($when / $minute);
+    $tmpsec = floor($when - ($tmpminute * 60));
+    return sprintf("%d min %d sec",$tmpminute,$tmpsec);
   } else {
-    $what = 'second';
-  }
-
-  if ($when != 1) $what .= 's';
-
-  if ($ago) {
-    return "$when $what $suffix";
-  } else {
-    return "$when $what";
+    return sprintf("%d sec",$when);
   }
 }
 

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -38,18 +38,18 @@ function format_ago($time) {
     $tmphour = floor(($when / $hour) - (24*$tmpday));
     $tmpminute = floor(($when / $minute) - (24*60*$tmpday) - ($tmphour * 60));
     $tmpsec = floor($when - (24*60*60*$tmpday) - ($tmphour * 60 * 60) - ($tmpminute * 60));
-    return sprintf("%d day %d hour %d minute %d sec",$tmpday,$tmphour,$tmpminute,$tmpsec);
+    return sprintf("%d day%s %d hour%s %d min%s %d sec%s",$tmpday,($tmpday != 1) ? 's' : '',$tmphour,($tmphour != 1) ? 's' : '',$tmpminute,($tmpminute != 1) ? 's' : '',$tmpsec,($tmpsec != 1) ? 's' : '');
   } else if ($when > $hour) {
     $tmphour = floor($when / $hour);
     $tmpminute = floor(($when / $minute) - ($tmphour * 60));
     $tmpsec = floor($when - ($tmphour * 60 * 60) - ($tmpminute * 60));
-    return sprintf("%d hour %d min %d sec",$tmphour,$tmpminute,$tmpsec);
+    return sprintf("%d hour%s %d min%s %d sec%s",$tmphour,($tmphour != 1) ? 's' : '',$tmpminute,($tmpminute != 1) ? 's' : '',$tmpsec,($tmpsec != 1) ? 's' : '');
   } else if ($when > $minute) {
     $tmpminute = floor($when / $minute);
     $tmpsec = floor($when - ($tmpminute * 60));
-    return sprintf("%d min %d sec",$tmpminute,$tmpsec);
+    return sprintf("%d min%s %d sec%s",$tmpminute,($tmpminute != 1) ? 's' : '',$tmpsec,($tmpsec != 1) ? 's' : '');
   } else {
-    return sprintf("%d sec",$when);
+    return sprintf("%d sec%s",$when,($when != 1) ? 's' : '');
   }
 }
 

--- a/overview.php
+++ b/overview.php
@@ -85,7 +85,7 @@ require 'includes/header.inc.php';
 
   <tr><td><div>Uptime:</div></td><td><div><?php echo format_ago($info[$i]['Server']['uptime_in_seconds'])?></div></td></tr>
 
-  <tr><td><div>Last save:</div></td><td><div><?php if (isset($info[$i]['Persistence']['rdb_last_save_time'])) { echo format_ago(time() - $info[$i]['Persistence']['rdb_last_save_time'], true); } else { echo 'never'; } ?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
+  <tr><td><div>Last save:</div></td><td><div><?php if (isset($info[$i]['Persistence']['rdb_last_save_time'])) { echo format_ago(time() - $info[$i]['Persistence']['rdb_last_save_time']); } else { echo 'never'; } ?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
 
   </table>
   <?php endif; ?>

--- a/overview.php
+++ b/overview.php
@@ -83,9 +83,9 @@ require 'includes/header.inc.php';
 
   <tr><td><div>Memory used:</div></td><td><div><?php echo format_size($info[$i]['Memory']['used_memory'])?></div></td></tr>
 
-  <tr><td><div>Uptime:</div></td><td><div><?php echo format_ago($info[$i]['Server']['uptime_in_seconds'])?></div></td></tr>
+  <tr><td><div>Uptime:</div></td><td><div><?php echo format_time($info[$i]['Server']['uptime_in_seconds'])?></div></td></tr>
 
-  <tr><td><div>Last save:</div></td><td><div><?php if (isset($info[$i]['Persistence']['rdb_last_save_time'])) { echo format_ago(time() - $info[$i]['Persistence']['rdb_last_save_time']); } else { echo 'never'; } ?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
+  <tr><td><div>Last save:</div></td><td><div><?php if (isset($info[$i]['Persistence']['rdb_last_save_time'])) { echo format_time(time() - $info[$i]['Persistence']['rdb_last_save_time']); } else { echo 'never'; } ?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
 
   </table>
   <?php endif; ?>

--- a/overview.php
+++ b/overview.php
@@ -85,7 +85,19 @@ require 'includes/header.inc.php';
 
   <tr><td><div>Uptime:</div></td><td><div><?php echo format_time($info[$i]['Server']['uptime_in_seconds'])?></div></td></tr>
 
-  <tr><td><div>Last save:</div></td><td><div><?php if (isset($info[$i]['Persistence']['rdb_last_save_time'])) { echo format_time(time() - $info[$i]['Persistence']['rdb_last_save_time']); } else { echo 'never'; } ?> <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
+  <tr><td><div>Last save:</div></td><td><div>
+    <?php 
+        if (isset($info[$i]['Persistence']['rdb_last_save_time'])) {
+           if((time() - $info[$i]['Persistence']['rdb_last_save_time'] ) >= 0) {
+              echo format_time(time() - $info[$i]['Persistence']['rdb_last_save_time']) . " ago";
+           } else { 
+              echo format_time(-(time() - $info[$i]['Persistence']['rdb_last_save_time'])) . "in the future"; 
+           } 
+        } else { 
+           echo 'never';
+        } 
+    ?> 
+    <a href="save.php?s=<?php echo $i?>"><img src="images/save.png" width="16" height="16" title="Save Now" alt="[S]" class="imgbut"></a></div></td></tr>
 
   </table>
   <?php endif; ?>


### PR DESCRIPTION
The original TTL conversion lifetime took the wrong rounding method, by modifying function. Inc. PHP to make its display more reasonable.