### PR TITLE
update FROM image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer/composer
+FROM composer:1.7
 
 ADD . /src/app/
 WORKDIR /src/app


### PR DESCRIPTION
changed base image from `composer/composer`, which is deprecated, to current `composer:1.7`
Also reduced image size from 650MB to 150MB.