### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/includes/config.environment.inc.php
+++ b/includes/config.environment.inc.php
@@ -16,7 +16,7 @@ if (!empty($admin_user)) {
 $i=1;
 $config['servers'] = array();
 
-while (TRUE) {
+while (true) {
 
   $prefix = 'REDIS_' . $i . '_';
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!