### PR TITLE
Docker - add proper PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ FROM composer:1.7
 ADD . /src/app/
 WORKDIR /src/app
 
+ENV TINI_VERSION 0.18.0-r0
+
 RUN \
+  apk add --no-cache tini=$TINI_VERSION && \
   composer install && \
   cp includes/config.environment.inc.php includes/config.inc.php
 
 EXPOSE 80
 
-ENTRYPOINT [ "php", "-S", "0.0.0.0:80" ]
+ENTRYPOINT [ "tini", "--", "php", "-S", "0.0.0.0:80" ]


### PR DESCRIPTION
PHP server is not good candidate for PID 1. It doesn't support SIGTERM correctly. More info you can find on [Tiny project](https://github.com/krallin/tini).