### PR TITLE
Remove `?>` php ending tag

### DIFF
--- a/includes/config.sample.inc.php
+++ b/includes/config.sample.inc.php
@@ -81,5 +81,3 @@ $config = array(
   // How many entries to fetch using each SCAN command.
   'scansize' => 1000
 );
-
-?>


### PR DESCRIPTION
The `?>` ending tag is optional in a pure `php` file.