### PR TITLE
fix keys ending in :0 shown as <empty>

### DIFF
--- a/index.php
+++ b/index.php
@@ -96,7 +96,7 @@ if($redis) {
           }
         }
 
-        if (empty($name)) {
+        if (empty($name) && $name != '0') {
           $name = '<empty>';
         }
 


### PR DESCRIPTION
I  have 2 keys in the database: `test:0` and `test:1`

Key `test:0` is shown as `<empty>`

<img width="149" alt="image" src="https://user-images.githubusercontent.com/223439/68987059-e34ad100-07f3-11ea-99c0-238eacf191a3.png">

This change fixes this.