### PR TITLE
fix reset stat code

### DIFF
--- a/info.php
+++ b/info.php
@@ -5,8 +5,8 @@ require_once 'includes/common.inc.php';
 
 
 
-if (isset($_GET['reset']) && method_exists($redis, 'resetStat')) {
-  $redis->resetStat();
+if (isset($_GET['reset'])) {
+  $redis->config('resetstat');
 
   header('Location: info.php');
   die;
@@ -29,11 +29,9 @@ require 'includes/header.inc.php';
 ?>
 <h2>Info</h2>
 
-<?php if (method_exists($redis, 'resetStat')) { ?>
 <p>
-<a href="?reset&amp;s=<?php echo $server['id']?>&amp;d=<?php echo $server['db']?>" class="reset">Reset usage statistics</a>
+<a href="?reset=1&amp;s=<?php echo $server['id']?>&amp;d=<?php echo $server['db']?>" class="reset">Reset usage statistics</a>
 </p>
-<?php } ?>
 
 <table>
 <tr><th><div>Key</div></th><th><div>Value</div></th></tr>


### PR DESCRIPTION
as mentioned earlier the method 'resetstat' does not exist and therefore the test will always be false.
config resetstat is part of redis forever, so there's no reason for testing for this functionality.