### PR TITLE
Remove usage of get_magic_quotes_gpc method

### DIFF
--- a/includes/common.inc.php
+++ b/includes/common.inc.php
@@ -3,26 +3,6 @@ require dirname(__FILE__) . '/../vendor/autoload.php';
 
 define('PHPREDIS_ADMIN_PATH', dirname(__DIR__));
 
-// Undo magic quotes (both in keys and values)
-if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
-  $process = array(&$_GET, &$_POST);
-
-  foreach ($process as $key => $val) {
-    foreach ($val as $k => $v) {
-      unset($process[$key][$k]);
-
-      if (is_array($v)) {
-        $process[$key][stripslashes($k)] = $v;
-        $process[] = &$process[$key][stripslashes($k)];
-      } else {
-        $process[$key][stripslashes($k)] = stripslashes($v);
-      }
-    }
-  }
-
-  unset($process);
-}
-
 
 
 


### PR DESCRIPTION
`get_magic_quotes_gpc()` method is deprecated and as of PHP 5.4 it returns false (i.e. the code inside the condition was never reached) - see https://www.php.net/manual/en/function.get-magic-quotes-gpc.php

This PR fixes PHP deprecation warning for PHP 7.4.