### PR TITLE
Allow 'databases' server config option to be set by ENV

### DIFF
--- a/includes/config.environment.inc.php
+++ b/includes/config.environment.inc.php
@@ -24,6 +24,7 @@ while (true) {
   $server_host = getenv($prefix . 'HOST');
   $server_port = getenv($prefix . 'PORT');
   $server_auth = getenv($prefix . 'AUTH');
+  $server_databases = getenv($prefix . 'DATABASES');
 
   if (empty($server_host)) {
     break;
@@ -50,6 +51,10 @@ while (true) {
   
   if (!empty($server_auth)) {
     $config['servers'][$i-1]['auth'] = $server_auth;
+  } 
+  
+  if (!empty($server_databases)) {
+    $config['servers'][$i-1]['databases'] = $server_databases;
   } 
 
   $i++;


### PR DESCRIPTION
This is quite specific to my needs, but possibly useful for others. 

My setup is PhpRedisAdmin running in Docker on ECS Fargate connnecting to Redis Elasticache. AWS Elasticache has a restricted CONFIG command so you can't get the databases.

This change allows me to set the databases in the Task Definition in ECS.