### PR TITLE
ADD DATABASES env var in the readme file #102

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,7 @@ Environment variables summary
 * ``REDIS_1_NAME`` - define name of the Redis server
 * ``REDIS_1_PORT`` - define port of the Redis server
 * ``REDIS_1_AUTH`` - define password of the Redis server
+* ``REDIS_1_DATABASES`` - You can modify you config to prevent phpRedisAdmin from using CONFIG command 
 * ``ADMIN_USER`` - define username for user-facing Basic Auth
 * ``ADMIN_PASS`` - define password for user-facing Basic Auth
 


### PR DESCRIPTION
following issue #102 

editing config.inc.php does not affect this variable and in config. environment.php we can find that you get DATABASES env var 

but yet it's not mentioned in the readme 

so this PR to add it to readme in case someone needed to set it 