### PR TITLE
Bring in tzdata so users could set the timezones through the environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM composer:2.2
 
 ENV TINI_VERSION 0.19.0-r0
 
-RUN apk add --no-cache tini=$TINI_VERSION
+RUN apk add --no-cache tini=$TINI_VERSION tzdata
 
 ADD . /src/app/
 


### PR DESCRIPTION
Supports using the `TZ` environment variable to set the timezone instead of using the volume bindings: `/etc/timezone:/etc/timezone` and `/etc/localtime:/etc/localtime`.

This is really great if you can support it.❤️