### PR TITLE
Update Dockerfile to enable change listen port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,6 @@ RUN composer install
 
 RUN cp includes/config.environment.inc.php includes/config.inc.php
 
+ENV PORT 80
 EXPOSE 80
-ENTRYPOINT [ "tini", "--", "php", "-S", "0.0.0.0:80" ]
+ENTRYPOINT [ "sh", "-c", "tini -- php -S 0.0.0.0:$PORT" ]


### PR DESCRIPTION
Docker can not change the exported port when in host mode, and port 80 open used by http server. So i made this to enable change the listening port by environment variables.