### PR TITLE
Update Dockerfile to enable change root context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN composer install
 
 RUN cp includes/config.environment.inc.php includes/config.inc.php
 
+ENV ROOT /
 ENV PORT 80
+
 EXPOSE 80
-ENTRYPOINT [ "sh", "-c", "tini -- php -S 0.0.0.0:$PORT" ]
+ENTRYPOINT ["sh", "-c", "mkdir -p /src/web/$ROOT && ln -sf /src/app/* /src/web/$ROOT/ && tini -- php -S 0.0.0.0:$PORT -t /src/web"]

--- a/README.markdown
+++ b/README.markdown
@@ -52,12 +52,14 @@ Also, a Docker Compose manifest with a stack for testing and development is prov
 Environment variables summary
 ====
 
+* ``ROOT`` - define URI basePath. Default: `/`
+* ``PORT`` - define port of the embedded server. Default: `80`
 * ``REDIS_1_HOST`` - define host of the Redis server
 * ``REDIS_1_NAME`` - define name of the Redis server
 * ``REDIS_1_PORT`` - define port of the Redis server
 * ``REDIS_1_AUTH`` - define password of the Redis server
 * ``REDIS_1_AUTH_FILE`` - define file containing the password of the Redis server
-* ``REDIS_1_DATABASES`` - You can modify you config to prevent phpRedisAdmin from using CONFIG command 
+* ``REDIS_1_DATABASES`` - You can modify you config to prevent phpRedisAdmin from using CONFIG command
 * ``ADMIN_USER`` - define username for user-facing Basic Auth
 * ``ADMIN_PASS`` - define password for user-facing Basic Auth
 

--- a/index.php
+++ b/index.php
@@ -154,7 +154,7 @@ if($redis) {
         return false; // we don't show empty dbs, so return false to tell the caller to continue the loop
       }
 
-      $dbinfo = sprintf("$prefix%'.-${padding}d", $d);
+      $dbinfo = sprintf("$prefix%'.-{$padding}d", $d);
       if ($dbHasData) {
         $dbinfo = sprintf("%s (%d)", $dbinfo, $info['Keyspace'][$db]['keys']);
       }


### PR DESCRIPTION
Update Dockerfile to enable change root context, and fix bug for "Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /src/app/index.php on line 157".