### PR TITLE
Limit the max number of keys when scanning

### DIFF
--- a/includes/config.environment.inc.php
+++ b/includes/config.environment.inc.php
@@ -2,6 +2,8 @@
 
 include 'config.sample.inc.php';
 
+$config['scan_max']                = getenv('SCAN_MAX')                    ?: 1000;
+
 $admin_user = getenv('ADMIN_USER');
 $admin_pass = getenv('ADMIN_PASS');
 
@@ -51,6 +53,7 @@ while (true) {
       'host'   => $server_host,
       'port'   => $server_port,
       'filter' => '*',
+      'scan_max' => $config['scan_max'],
   );
   
   if (!empty($server_auth)) {

--- a/includes/config.environment.inc.php
+++ b/includes/config.environment.inc.php
@@ -2,7 +2,7 @@
 
 include 'config.sample.inc.php';
 
-$config['scan_max']                = getenv('SCAN_MAX')                    ?: 1000;
+$config['scanmax']                = getenv('SCAN_MAX')                    ?: 1000;
 
 $admin_user = getenv('ADMIN_USER');
 $admin_pass = getenv('ADMIN_PASS');
@@ -53,7 +53,7 @@ while (true) {
       'host'   => $server_host,
       'port'   => $server_port,
       'filter' => '*',
-      'scan_max' => $config['scan_max'],
+      'scanmax'  => $config['scanmax'],
   );
   
   if (!empty($server_auth)) {

--- a/includes/config.sample.inc.php
+++ b/includes/config.sample.inc.php
@@ -32,7 +32,8 @@ $config = array(
       'flush'     => false,         // Set to true to enable the flushdb button for this instance.
       'charset'   => 'cp1251',      // Keys and values are stored in redis using this encoding (default utf-8).
       'keys'      => false,         // Use the old KEYS command instead of SCAN to fetch all keys for this server (default uses config default).
-      'scansize'  => 1000           // How many entries to fetch using each SCAN command for this server (default uses config default).
+      'scansize'  => 1000,          // How many entries to fetch using each SCAN command for this server (default uses config default).
+      'scanmax'   => 1000,          // In each query, SCAN command may be executed several times. To shorten the duration, it is recommended to limit the total number of entries to fetch.
     ),*/
   ),
 

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ if($redis) {
             $next = $r[0];
             $keys = array_merge($keys, $r[1]);
 
-            if (count($keys) >= $server['scan_max']) {
+            if (count($keys) >= $server['scanmax']) {
                 break;
             }
 

--- a/index.php
+++ b/index.php
@@ -17,6 +17,10 @@ if($redis) {
             $next = $r[0];
             $keys = array_merge($keys, $r[1]);
 
+            if (count($keys) >= $server['scan_max']) {
+                break;
+            }
+
             if ($next == 0) {
                 break;
             }


### PR DESCRIPTION
Hi, glad to see you're still maintaining this 12 year old project!
Among the redis web GUI tools, phpRedisAdmin is still the most powerful one.

But now there is a serious problem: if the redis db contains more than 100,000 keys, it takes phpRedisAdmin tens of seconds to open the db, or even timeout.
I have a simple solution: limit the max number of keys when scanning.

For reference, AnotherRedisDesktopManager also has this limitation, and the max number is 500.
https://github.com/qishibo/AnotherRedisDesktopManager/blob/d373d653063c2a0c256c743777118b92231010ba/src/components/contents/KeyContentStream.vue#L199