### PR TITLE
Display the number of keys scanned

### DIFF
--- a/index.php
+++ b/index.php
@@ -255,7 +255,7 @@ if ($databases > 1) { ?>
 </div>
 <div id="keys">
 <div class="info">
-  scaned <?php echo count($keys) ?> keys<?php echo (count($keys) < $server['scanmax']) ? '' : ", reached {$server['scanmax']} limit" ?>
+  scaned <?php echo count($keys) ?> keys<?php echo (count($keys) >= $server['scanmax']) ? ', reached scanmax' : '' ?>
 </div>
 <ul>
 <?php print_namespace($namespaces, 'Keys', '', empty($namespaces))?>

--- a/index.php
+++ b/index.php
@@ -256,6 +256,9 @@ if ($databases > 1) { ?>
 </button>
 </div>
 <div id="keys">
+<div class="info">
+  scaned <?php echo count($keys) ?> keys<?php echo (count($keys) < $server['scanmax']) ? '' : ", reached {$server['scanmax']} limit" ?>
+</div>
 <ul>
 <?php print_namespace($namespaces, 'Keys', '', empty($namespaces))?>
 </ul>

--- a/index.php
+++ b/index.php
@@ -10,20 +10,18 @@ if($redis) {
     } else {
         $next = 0;
         $keys = array();
-
+        $scansize = $server['scansize'];
         while (true) {
-            $r = $redis->scan($next, 'MATCH', $server['filter'], 'COUNT', $server['scansize']);
-
+            $r = $redis->scan($next, 'MATCH', $server['filter'], 'COUNT', $scansize);
             $next = $r[0];
             $keys = array_merge($keys, $r[1]);
-
-            if (count($keys) >= $server['scanmax']) {
-                break;
-            }
-
             if ($next == 0) {
                 break;
             }
+            if (count($keys) >= $server['scanmax']) {
+                break;
+            }
+            $scansize = min($server['scanmax'] - count($keys), $server['scansize']);
         }
     }
 


### PR DESCRIPTION
This PR is a patch for [#206](https://github.com/erikdubbelboer/phpRedisAdmin/pull/206#issuecomment-2360251417) , to make users see how many keys have been scanned.
Even if scanmax is not considered, it is helpful to display the number of keys scanned.

It is displayed like this:
![screenshot-20240920-114632](https://github.com/user-attachments/assets/c3a0bdb6-97fd-425e-b299-37ee80872ee1)
![screenshot-20240920-114748](https://github.com/user-attachments/assets/7325b66f-de3a-4061-877b-5b9b994d0f90)

The information displayed needs to be touched up, so that it is clear enough for users.