### PR TITLE
fix: scanmax behavior

### DIFF
--- a/includes/common.inc.php
+++ b/includes/common.inc.php
@@ -95,8 +95,20 @@ if (!isset($server['keys'])) {
   $server['keys'] = $config['keys'];
 }
 
+if (!isset($config['scansize'])) {
+  $config['scansize'] = 1000;
+}
+
+if (!isset($config['scanmax'])) {
+  $config['scanmax'] = 0;
+}
+
 if (!isset($server['scansize'])) {
   $server['scansize'] = $config['scansize'];
+}
+
+if (!isset($server['scanmax'])) {
+  $server['scanmax'] = $config['scanmax'];
 }
 
 if (!isset($server['serialization'])) {

--- a/includes/config.sample.inc.php
+++ b/includes/config.sample.inc.php
@@ -33,7 +33,7 @@ $config = array(
       'charset'   => 'cp1251',      // Keys and values are stored in redis using this encoding (default utf-8).
       'keys'      => false,         // Use the old KEYS command instead of SCAN to fetch all keys for this server (default uses config default).
       'scansize'  => 1000,          // How many entries to fetch using each SCAN command for this server (default uses config default).
-      'scanmax'   => 1000,          // In each query, SCAN command may be executed several times. To shorten the duration, it is recommended to limit the total number of entries to fetch.
+      'scanmax'   => 1000,          // In each query, SCAN command may be executed several times. To shorten the duration, it is recommended to limit the total number of entries to fetch (default uses config default).
     ),*/
   ),
 
@@ -85,4 +85,7 @@ $config = array(
 
   // How many entries to fetch using each SCAN command.
   'scansize' => 1000
+
+  // The total number of entries to fetch. Set to 0 or -1 for no limit.
+  'scanmax' => 0
 );

--- a/index.php
+++ b/index.php
@@ -255,7 +255,7 @@ if ($databases > 1) { ?>
 </div>
 <div id="keys">
 <div class="info">
-  scaned <?php echo count($keys) ?> keys<?php echo (count($keys) >= $server['scanmax']) ? ', reached scanmax' : '' ?>
+  scanned <?php echo count($keys) ?> keys<?php echo (count($keys) >= $server['scanmax']) ? ', reached scanmax' : '' ?>
 </div>
 <ul>
 <?php print_namespace($namespaces, 'Keys', '', empty($namespaces))?>

--- a/index.php
+++ b/index.php
@@ -10,18 +10,16 @@ if($redis) {
     } else {
         $next = 0;
         $keys = array();
-        $scansize = $server['scansize'];
         while (true) {
-            $r = $redis->scan($next, 'MATCH', $server['filter'], 'COUNT', $scansize);
+            $r = $redis->scan($next, 'MATCH', $server['filter'], 'COUNT', $server['scansize']);
             $next = $r[0];
             $keys = array_merge($keys, $r[1]);
             if ($next == 0) {
                 break;
             }
-            if (count($keys) >= $server['scanmax']) {
+            if ($server['scanmax'] > 0 && count($keys) >= $server['scanmax']) {
                 break;
             }
-            $scansize = min($server['scanmax'] - count($keys), $server['scansize']);
         }
     }
 
@@ -255,7 +253,7 @@ if ($databases > 1) { ?>
 </div>
 <div id="keys">
 <div class="info">
-  scanned <?php echo count($keys) ?> keys<?php echo (count($keys) >= $server['scanmax']) ? ', reached scanmax' : '' ?>
+  scanned <?php echo count($keys) ?> keys<?php echo ($server['scanmax'] > 0 && count($keys) >= $server['scanmax']) ? ', reached scanmax' : '' ?>
 </div>
 <ul>
 <?php print_namespace($namespaces, 'Keys', '', empty($namespaces))?>


### PR DESCRIPTION
This PR fixes incorrect and undefined behavior, and has a performance item as well.

1. If `scanmax` or `scansize` are not set globally or in a server context, the default values `0` and `1000` are used respectively.
2. Allow to fetch all keys by setting `scanmax` to `0` or `-1`
3. The `scanmax` value can now be set globally (will be overridden when set in the server context)
4. Got rid of the `$scansize = min($server['scanmax'] - count($keys), $server['scansize']);` construct, because it's a perf trap.
It has to count all keys and do other arithmetics in every loop just to scan less than scansize in the very last iteration of the loop. This is not good for performance.

fixes #211