### PR TITLE
Implement ACL Login

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "401ff61cebe5223d003a47192d7c3d6a",
+    "content-hash": "9ebfdd83053d61e2db192229cc39f2d8",
     "packages": [
         {
             "name": "paragonie/random_compat",

--- a/css/frame.css
+++ b/css/frame.css
@@ -52,3 +52,11 @@ float: left;
 margin: 1em;
 }
 
+.exception {
+    border: 1px solid #ff0000;
+    background-color: rgba(255, 0, 0, 0.2);
+    color: #880000;
+    padding: 10px;
+    border-radius: 5px;
+    margin: 20px;
+}

--- a/includes/config.sample.inc.php
+++ b/includes/config.sample.inc.php
@@ -47,20 +47,6 @@ $config = array(
   // Uncomment to show less information and make phpRedisAdmin fire less commands to the Redis server. Recommended for a really busy Redis server.
   //'faster' => true,
 
-
-  // Uncomment to enable HTTP authentication
-  /*'login' => array(
-    // Username => Password
-    // Multiple combinations can be used
-    'admin' => array(
-      'password' => 'adminpassword',
-    ),
-    'guest' => array(
-      'password' => '',
-      'servers'  => array(1) // Optional list of servers this user can access.
-    )
-  ),*/
-
   // Use HTML form/cookie-based auth instead of HTTP Basic/Digest auth
   'cookie_auth' => false,
 

--- a/includes/login.inc.php
+++ b/includes/login.inc.php
@@ -1,65 +1,48 @@
 <?php
 
+function authCheck($login)
+{
+    global $redis, $server;
+
+    // $server['username'] = $login['username'];
+    // $server['password'] = $login['password'];
+
+    // $redis = new Predis\Client($server);
+
+    // try {
+    //     $redis->connect();
+    // } catch (Predis\CommunicationException $exception) {
+    //     die('ERROR: ' . $exception->getMessage());
+    // }
+
+    try {
+        $redis->auth($login['username'], $login['password']);
+    } catch (Predis\Response\ServerException $exception) {
+        return false;
+    }
+    return true;
+}
+
 // This fill will perform HTTP digest authentication. This is not the most secure form of authentication so be carefull when using this.
 function authHttpDigest()
 {
-    global $config;
-
     $realm = 'phpRedisAdmin';
 
-    // Using the md5 of the user agent and IP should make it a bit harder to intercept and reuse the responses.
-    $opaque = md5('phpRedisAdmin'.$_SERVER['HTTP_USER_AGENT'].$_SERVER['REMOTE_ADDR']);
-
-
-    if (!isset($_SERVER['PHP_AUTH_DIGEST']) || empty($_SERVER['PHP_AUTH_DIGEST'])) {
-      header('HTTP/1.1 401 Unauthorized');
-      header('WWW-Authenticate: Digest realm="'.$realm.'",qop="auth",nonce="'.uniqid().'",opaque="'.$opaque.'"');
-      die;
+    if (!isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
+        header('HTTP/1.1 401 Unauthorized');
+        header('WWW-Authenticate: Basic realm="' . $realm . '"');
+        die('NOAUTH -- Authentication required');
     }
 
-    $needed_parts = array(
-      'nonce'    => 1,
-      'nc'       => 1,
-      'cnonce'   => 1,
-      'qop'      => 1,
-      'username' => 1,
-      'uri'      => 1,
-      'response' => 1
-     );
+    $login = [
+        'username' => $_SERVER['PHP_AUTH_USER'],
+        'password' => $_SERVER['PHP_AUTH_PW'],
+    ];
 
-    $data = array();
-    $keys = implode('|', array_keys($needed_parts));
-
-    preg_match_all('/('.$keys.')=(?:([\'"])([^\2]+?)\2|([^\s,]+))/', $_SERVER['PHP_AUTH_DIGEST'], $matches, PREG_SET_ORDER);
-
-    foreach ($matches as $m) {
-      $data[$m[1]] = $m[3] ? $m[3] : $m[4];
-      unset($needed_parts[$m[1]]);
-    }
-
-    if (!empty($needed_parts)) {
-      header('HTTP/1.1 401 Unauthorized');
-      header('WWW-Authenticate: Digest realm="'.$realm.'",qop="auth",nonce="'.uniqid().'",opaque="'.$opaque.'"');
-      die;
-    }
-
-    if (!isset($config['login'][$data['username']])) {
-      header('HTTP/1.1 401 Unauthorized');
-      header('WWW-Authenticate: Digest realm="'.$realm.'",qop="auth",nonce="'.uniqid().'",opaque="'.$opaque.'"');
-      die('Invalid username and/or password combination.');
-    }
-
-    $login         = $config['login'][$data['username']];
-    $login['name'] = $data['username'];
-
-    $password = md5($login['name'].':'.$realm.':'.$login['password']);
-
-    $response = md5($password.':'.$data['nonce'].':'.$data['nc'].':'.$data['cnonce'].':'.$data['qop'].':'.md5($_SERVER['REQUEST_METHOD'].':'.$data['uri']));
-
-    if ($data['response'] !== $response) {
-      header('HTTP/1.1 401 Unauthorized');
-      header('WWW-Authenticate: Digest realm="'.$realm.'",qop="auth",nonce="'.uniqid().'",opaque="'.$opaque.'"');
-      die('Invalid username and/or password combination.');
+    if (!authCheck($login)) {
+        header('HTTP/1.1 401 Unauthorized');
+        header('WWW-Authenticate: Basic realm="' . $realm . '"');
+        die('NOAUTH -- Authentication required');
     }
 
     return $login;
@@ -68,58 +51,33 @@ function authHttpDigest()
 // Perform auth using a standard HTML <form> submission and cookies to save login state
 function authCookie()
 {
-    global $config;
-
-    $generateCookieHash = function($username) use ($config) {
-        if (!isset($config['login'][$username])) {
-            throw new \RuntimeException("Invalid username");
-        }
-
-        // Storing this value client-side so we need to be careful that it
-        //  doesn't reveal anything nor can be guessed.
-        // Using SHA512 because MD5, SHA1 are both now considered broken
-        return hash(
-            'sha512',
-            implode(':', array(
-                $username,
-                $_SERVER['HTTP_USER_AGENT'],
-                $_SERVER['REMOTE_ADDR'],
-                $config['login'][$username]['password'],
-            ))
-        );
-    };
-
-    if (!empty($_COOKIE['phpRedisAdminLogin'])) {
+    if (!empty($_SESSION['phpRedisAdminLogin'])) {
         // We have a cookie; is it correct?
         // Cookie value looks like "username:password-hash"
-        $cookieVal = explode(':', $_COOKIE['phpRedisAdminLogin']);
-        if (count($cookieVal) === 2) {
-            list($username, $cookieHash) = $cookieVal;
-            if (isset($config['login'][$username])) {
-                $userData = $config['login'][$username];
-                $expectedHash = $generateCookieHash($username);
-
-                if ($cookieHash === $expectedHash) {
-                    // Correct username & password
-                    return $userData;
-                }
+        $login = explode(':', $_SESSION['phpRedisAdminLogin']);
+        if (count($login) === 2) {
+            $login = [
+                'username' => $login[0],
+                'password' => $login[1],
+            ];
+            if (authCheck($login)) {
+                return $login;
             }
         }
     }
 
     if (isset($_POST['username'], $_POST['password'])) {
         // Login form submitted; correctly?
-        if (isset($config['login'][$_POST['username']])) {
-            $userData = $config['login'][$_POST['username']];
-            if ($_POST['password'] === $userData['password']) {
-                // Correct username & password. Set cookie and redirect to home page
-                $cookieValue = $_POST['username'] . ':' . $generateCookieHash($_POST['username']);
-                setcookie('phpRedisAdminLogin', $cookieValue);
+        $login = [
+            'username' => $_POST['username'],
+            'password' => $_POST['password'],
+        ];
 
-                // This should be an absolute URL, but that's a bit of a pain to generate; this will work
-                header("Location: index.php");
-                die();
-            }
+        if (authCheck($login)) {
+            $_SESSION['phpRedisAdminLogin'] =  $login['username'] . ':' . $login['password'];
+            // This should be an absolute URL, but that's a bit of a pain to generate; this will work
+            header("Location: index.php");
+            die();
         }
     }
 
@@ -140,5 +98,3 @@ if (!empty($config['cookie_auth'])) {
 } else {
     $login = authHttpDigest();
 }
-
-?>

--- a/index.php
+++ b/index.php
@@ -82,7 +82,15 @@ if($redis) {
 
         // Get the number of items in the key.
         if (!isset($config['faster']) || !$config['faster']) {
-          switch ($redis->type($fullkey)) {
+          $type = '';
+          try {
+            $type = $redis->type($fullkey);
+          } catch (\Predis\Response\ServerException $th) {
+            $type = 'NOPERM';
+            $class[] = 'empty';
+          }
+
+          switch ($type) {
             case 'hash':
               $len = $redis->hLen($fullkey);
               break;

--- a/logout.php
+++ b/logout.php
@@ -1,52 +1,20 @@
 <?php
 
-require_once 'includes/common.inc.php';
-global $redis, $config, $csrfToken, $server;
+define('PHPREDIS_ADMIN_PATH', __DIR__);
+
+if (file_exists(PHPREDIS_ADMIN_PATH . '/includes/config.inc.php')) {
+  require_once PHPREDIS_ADMIN_PATH . '/includes/config.inc.php';
+} else {
+  require_once PHPREDIS_ADMIN_PATH . '/includes/config.sample.inc.php';
+}
 
 if (!empty($config['cookie_auth'])) {
-    // Cookie-based auth
-    setcookie('phpRedisAdminLogin', '', 1);
-    header("Location: login.php");
-    die();
+  // Cookie-based auth
+  session_start();
+  unset($_SESSION['phpRedisAdminLogin']);
+  header("Location: login.php");
+  die();
 } else {
-    // HTTP Digest auth
-    $needed_parts = array(
-      'nonce'    => 1,
-      'nc'       => 1,
-      'cnonce'   => 1,
-      'qop'      => 1,
-      'username' => 1,
-      'uri'      => 1,
-      'response' => 1
-     );
-
-    $data = array();
-    $keys = implode('|', array_keys($needed_parts));
-
-    preg_match_all('/('.$keys.')=(?:([\'"])([^\2]+?)\2|([^\s,]+))/', $_SERVER['PHP_AUTH_DIGEST'], $matches, PREG_SET_ORDER);
-
-    foreach ($matches as $m) {
-      $data[$m[1]] = $m[3] ? $m[3] : $m[4];
-      unset($needed_parts[$m[1]]);
-    }
-
-
-    if (!isset($_GET['nonce'])) {
-      header('Location: logout.php?nonce='.$data['nonce']);
-      die;
-    }
-
-
-    if ($data['nonce'] == $_GET['nonce']) {
-      unset($_SERVER['PHP_AUTH_DIGEST']);
-
-      if (!empty($config['cookie_auth'])) {
-          $login = authCookie();
-      } else {
-          $login = authHttpDigest();
-      }
-    }
-
-
-    header('Location: logout.php');
+  header('HTTP/1.1 401 Unauthorized');
+  die('<html><head><meta http-equiv="refresh" content="0; url=/index.php" /></head></html>');
 }

--- a/overview.php
+++ b/overview.php
@@ -10,18 +10,6 @@ foreach ($config['servers'] as $i => $server) {
       $server['db'] = 0;
   }
 
-  // Setup a connection to Redis.
-  if(isset($server['scheme']) && $server['scheme'] === 'unix' && $server['path']) {
-    $redis = new Predis\Client(array('scheme' => 'unix', 'path' => $server['path']));
-  } else {
-    $redis = !$server['port'] ? new Predis\Client($server['host']) : new Predis\Client('tcp://'.$server['host'].':'.$server['port']);
-  }
-  try {
-    $redis->connect();
-  } catch (Predis\CommunicationException $exception) {
-    $redis = false;
-  }
-
   if(!$redis) {
       $info[$i] = false;
   } else {
@@ -38,6 +26,7 @@ foreach ($config['servers'] as $i => $server) {
 
       $info[$i]         = $redis->info();
       $info[$i]['size'] = $redis->dbSize();
+      $info[$i]['username'] = $redis->acl->whoami();
 
       if (!isset($info[$i]['Server'])) {
         $info[$i]['Server'] = array(
@@ -82,6 +71,8 @@ require 'includes/header.inc.php';
   <tr><td><div>Memory used:</div></td><td><div><?php echo format_size($info[$i]['Memory']['used_memory'])?></div></td></tr>
 
   <tr><td><div>Uptime:</div></td><td><div><?php echo format_time($info[$i]['Server']['uptime_in_seconds'])?></div></td></tr>
+
+  <tr><td><div>ACL username:</div></td><td><div><?php echo ($info[$i]['username'])?></div></td></tr>
 
   <tr><td><div>Last save:</div></td><td><div>
     <?php 

--- a/ttl.php
+++ b/ttl.php
@@ -31,7 +31,7 @@ require 'includes/header.inc.php';
 
 <p>
 <label for="ttl"><abbr title="Time To Live">TTL</abbr>:</label>
-<input type="text" name="ttl" id="ttl" size="30" <?php echo isset($_GET['ttl']) ? 'value="'.format_html($_GET['ttl']).'"' : ''?>> <span class="info">(-1 to remove the TTL)</span>
+<input type="number" min="-1" name="ttl" id="ttl" size="30" <?php echo isset($_GET['ttl']) ? 'value="'.format_html($_GET['ttl']).'"' : ''?>> <span class="info">(-1 to remove the TTL)</span>
 </p>
 
 <input type="submit" class="button" value="Edit TTL">

--- a/view.php
+++ b/view.php
@@ -17,8 +17,19 @@ if (!isset($_GET['key'])) {
   die;
 }
 
-$type   = $redis->type($_GET['key']);
-$exists = $redis->exists($_GET['key']);
+$type = ''; 
+$exists = false;
+try {
+  $type   = $redis->type($_GET['key']);
+  $exists = $redis->exists($_GET['key']);
+} catch (\Predis\Response\ServerException $th) {
+  $type = 'NOPERM';
+?>
+   <div class="exception">
+      <h3><?php echo $th->getMessage() ?></h3>
+  </div>
+  <?php
+}
 
 $count_elements_page = isset($config['count_elements_page']) ? $config['count_elements_page'] : false;
 $page_num_request    = isset($_GET['page']) ? (int)$_GET['page'] : 1;


### PR DESCRIPTION
This enables the login page to truly check with ACL configuration instead of checking with username/password config.

It also:
- When default user is `off`, the web redirects to login page
- Make logout a bit nicer for Basic Auth
- Handle access exceptions if ACL denies to query some keys

This works for my need but I need feedback before I can make this changes a bit nicer, as it's currently includes a breaking changes such as
- Changed from Auth digest to Auth basic
- `config['login']` no longer works
- Changed cookie login to store it session